### PR TITLE
Add support for explicitly passing `--delete` to `rsync`

### DIFF
--- a/modules/cloner-script.nix
+++ b/modules/cloner-script.nix
@@ -47,6 +47,7 @@
         then "${deployment.remote.user.name}@${deployment.remote.ipOrHostname}:${deployment.targetDir} "
         else "${deployment.targetDir} "
       }"
+      + "${if deployment.should-propagate-file-deletion then "--delete " else ""}"
   );
 
   uniqueRsyncCmd = (

--- a/modules/options.nix
+++ b/modules/options.nix
@@ -124,6 +124,11 @@
             };
           });
       };
+      should-propagate-file-deletion = lib.mkOption {
+        type = lib.types.bool;
+        default = false;
+        description = "pass `--delete` to `rsync`; when file is deleted on `source`, also delete backed up file in `remote`";
+      };
     };
   };
 in {


### PR DESCRIPTION
allow for passing `--delete` to `rsync` to prevent backups from growing indefinitely in size